### PR TITLE
add unambigious license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,6 @@ All dependencies are Apache 2.0 licensed (AndroidX / Jetpack). No third-party li
 
 ## License
 
+[![GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](https://spdx.org/licenses/GPL-3.0-or-later.html)
+
 GPL-3.0-or-later — see [LICENSE](LICENSE).


### PR DESCRIPTION
* this badge adds unambigious license badge with spdx license text
* inspiration: 
  * For Clarity's Sake, Please Don't Say “Licensed under GNU GPL 2”! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html