### PR TITLE
Bump compileSdk to 36 + AndroidX/Kotlin deps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace  = "com.minesweeper"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId  = "io.github.johnathan.minesweeper"
@@ -41,8 +41,8 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.animation:animation")
     implementation("androidx.compose.foundation:foundation")
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.activity:activity-compose:1.13.0")
+    implementation("androidx.core:core-ktx:1.19.0")
     debugImplementation("androidx.compose.ui:ui-tooling")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
     id("com.android.application")             version "9.3.0" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
 }


### PR DESCRIPTION
compileSdk 35→36 (targetSdk stays 35), Kotlin compose plugin 2.2.21→2.4.10, activity-compose 1.13.0, core-ktx 1.19.0. Supersedes #9/#10. Verifying via CI.